### PR TITLE
愛知県にないデータのグラフを一時的に非表示

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,6 +13,7 @@
       :btn-text="'相談の手順を見る'"
     />
     <v-row class="DataBlock">
+      <!--
       <v-col cols="12" md="6" class="DataCard">
         <svg-card
           title="検査陽性者の状況"
@@ -22,6 +23,7 @@
           <confirmed-cases-table v-bind="confirmedCases" />
         </svg-card>
       </v-col>
+      -->
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="陽性患者数"
@@ -48,6 +50,7 @@
           "
         />
       </v-col>
+      <!--
       <v-col cols="12" md="6" class="DataCard">
         <time-stacked-bar-chart
           title="検査実施数"
@@ -92,6 +95,7 @@
           :date="metroGraph.date"
         />
       </v-col>
+      -->
     </v-row>
   </div>
 </template>
@@ -99,8 +103,8 @@
 <script>
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
-import MetroBarChart from '@/components/MetroBarChart.vue'
-import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
+// import MetroBarChart from '@/components/MetroBarChart.vue'
+// import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
 import Data from '@/data/data.json'
@@ -110,20 +114,20 @@ import formatGraph from '@/utils/formatGraph'
 import formatTable from '@/utils/formatTable'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
 import News from '@/data/news.json'
-import SvgCard from '@/components/SvgCard.vue'
-import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
+// import SvgCard from '@/components/SvgCard.vue'
+// import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
 
 export default {
   components: {
     PageHeader,
     TimeBarChart,
-    MetroBarChart,
-    TimeStackedBarChart,
+    //    MetroBarChart,
+    //    TimeStackedBarChart,
     WhatsNew,
     StaticInfo,
-    DataTable,
-    SvgCard,
-    ConfirmedCasesTable
+    DataTable
+    //    SvgCard,
+    //    ConfirmedCasesTable
   },
   data() {
     // 感染者数グラフ


### PR DESCRIPTION
## 📝 関連issue / Related Issues
 - https://github.com/code4nagoya/covid19/issues/10

## ⛏ 変更内容 / Details of Changes
 - 陽性患者数・陽性患者の属性のグラフは出せそうとのことなので、公開にむけて最小限のグラフにする

## 📸 スクリーンショット / Screenshots
<img width="1067" alt="スクリーンショット 2020-03-10 22 29 16" src="https://user-images.githubusercontent.com/1971086/76316876-9a78d400-631e-11ea-902c-8a40ab396681.png">

