### PR TITLE
ステータスバッジのURLを愛知のものに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 愛知県 新型コロナウイルス感染症対策サイト
 
-![](https://github.com/tokyo-metropolitan-gov/covid19/workflows/production%20deploy/badge.svg)
+![](https://github.com/code4nagoya/covid19/workflows/production%20deploy/badge.svg)
 
 [![愛知県 新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)](https://stopcovid19.metro.tokyo.lg.jp/)
 


### PR DESCRIPTION
ステータスバッジURLが東京のリポジトリのままだったので、愛知のリポジトリのURLに変更