### PR TITLE
タイトルとOGPを愛知県のものに変更

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,7 +30,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://stopcovid19.metro.tokyo.lg.jp'
+        content: 'https://stopcovid19.code4.nagoya'
       },
       {
         hid: 'og:title',
@@ -46,7 +46,7 @@ const config: Configuration = {
       {
         hid: 'og:image',
         property: 'og:image',
-        content: 'https://stopcovid19.metro.tokyo.lg.jp/ogp.png'
+        content: 'https://stopcovid19.code4.nagoya/ogp.png'
       },
       {
         hid: 'twitter:card',
@@ -56,17 +56,17 @@ const config: Configuration = {
       {
         hid: 'twitter:site',
         name: 'twitter:site',
-        content: '@tokyo_bousai'
+        content: '@code4nagoya'
       },
       {
         hid: 'twitter:creator',
         name: 'twitter:creator',
-        content: '@tokyo_bousai'
+        content: '@code4nagoya'
       },
       {
         hid: 'twitter:image',
         name: 'twitter:image',
-        content: 'https://stopcovid19.metro.tokyo.lg.jp/ogp.png'
+        content: 'https://stopcovid19.code4.nagoya/ogp.png'
       }
     ],
     link: [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -145,11 +145,11 @@ export default {
     const metroGraph = MetroData
     // 検査実施日別状況
     const inspectionsGraph = [
-      Data.inspections_summary.data['都内'],
+      Data.inspections_summary.data['県内'],
       Data.inspections_summary.data['その他']
     ]
     const inspectionsItems = [
-      '都内発生（疑い例・接触者調査）',
+      '県内発生（疑い例・接触者調査）',
       'その他（チャーター便・クルーズ便）'
     ]
     const inspectionsLabels = Data.inspections_summary.labels
@@ -184,7 +184,7 @@ export default {
       sumInfoOfPatients,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
-        title: '都内の最新感染動向',
+        title: '愛知県内の最新感染動向',
         date: Data.lastUpdate
       },
       newsItems: News.newsItems,
@@ -246,7 +246,7 @@ export default {
   },
   head() {
     return {
-      title: '都内の最新感染動向'
+      title: '県内の最新感染動向'
     }
   }
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues
issue : https://github.com/code4nagoya/covid19/issues/12

## ⛏ 変更内容 / Details of Changes
 - タイトルの都内->愛知県内
- OGPの画像とリンク系のURLを変更

## 📸 スクリーンショット / Screenshots
