### PR TITLE
スマホ版でサイドバーがスクロールできないバグを解消

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -258,6 +258,7 @@ export default {
 .open {
   @include lessThan($small) {
     position: fixed;
+    overflow: auto;
     top: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
## 📝 関連issue / Related Issues


- close #69 

## ⛏ 変更内容 / Details of Changes

- スマホ版でもスクロールできることを確認しました
- 以下で動作することを確認しました。
- Chrome 80.0.3987.132
- Firefox 73.0.1
- Safari 13.0.5

## 📸 スクリーンショット / Screenshots
<img width="285" alt="スクリーンショット 2020-03-12 13 27 25" src="https://user-images.githubusercontent.com/22832130/76487260-3f052e00-6465-11ea-8ad9-696e920ab298.png">
