### PR TITLE
埼玉県版をリンク追加

### DIFF
--- a/pages/government.vue
+++ b/pages/government.vue
@@ -4,6 +4,7 @@
       他自治体の対策サイト
     </h2>
     <TextCard title="北海道" link="https://stopcovid19.hokkaido.dev/" />
+    <TextCard title="埼玉県" link="https://stopcovid19.e-toda.jp/" />
     <TextCard title="東京都" link="https://stopcovid19.metro.tokyo.lg.jp/" />
     <TextCard
       title="神奈川県"


### PR DESCRIPTION
## 📝 関連issue / Related Issues


- close #74 

## ⛏ 変更内容 / Details of Changes

- 埼玉県版を追加しました。
- 都道府県の順番は本家に則り以下記載の順番としました

https://www.mhlw.go.jp/topics/2007/07/dl/tp0727-1d.pdf


## 📸 スクリーンショット / Screenshots
<img width="380" alt="スクリーンショット 2020-03-13 12 43 48" src="https://user-images.githubusercontent.com/22832130/76587762-50633e80-6528-11ea-8835-6b8a2895ef29.png">

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
