### PR TITLE
Fix Deprecation warning in chart.js

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -214,6 +214,7 @@ export default {
               },
               type: 'time',
               time: {
+                parser: 'M/D',
                 unit: 'month'
               }
             }


### PR DESCRIPTION
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. の修正

see; https://stackoverflow.com/questions/54334676/chart-js-format-date-in-label