### PR TITLE
「県内の最新感染動向」の下に罫線追加

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -121,7 +121,8 @@ export default {
         {
           icon: 'mdi-chart-timeline-variant',
           title: this.$t('The latest updates'),
-          link: '/'
+          link: '/',
+          divider: true
         },
         // {
         //   icon: 'covid',


### PR DESCRIPTION
## 📝 関連issue / Related Issues
#108
- close #108

## ⛏ 変更内容 / Details of Changes
`components/SideNavigation.vue`

の県内の最新感染動向に該当する部分に

divider: trueを追記

## 📸 スクリーンショット / Screenshots

### before

<img width="246" alt="スクリーンショット 2020-03-20 5 02 46" src="https://user-images.githubusercontent.com/39574826/77109913-1b934200-6a68-11ea-85c1-b44305a47b1f.png">

### after

<img width="242" alt="スクリーンショット 2020-03-20 5 02 19" src="https://user-images.githubusercontent.com/39574826/77109953-2bab2180-6a68-11ea-81a5-3c7b85642293.png">

