### PR TITLE
愛知県内の発生状況と相談窓口へのリンク修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -139,7 +139,7 @@ export default {
           icon: 'mdi-account-multiple',
           title: this.$t('for Citizens'),
           link:
-            'https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html'
+            'https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html'
         },
         {
           icon: 'mdi-domain',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,7 +32,7 @@
           :date="Data.patients.date"
           :unit="'人'"
           :url="
-            'https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html'
+            'https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html'
           "
         />
       </v-col>
@@ -46,7 +46,7 @@
           :date="Data.patients.date"
           :info="sumInfoOfPatients"
           :url="
-            'https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html'
+            'https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html'
           "
         />
       </v-col>

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -25,7 +25,7 @@ export default {
         {
           title: '2 感染症を疑う場合の対応',
           body:
-            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（愛知県保健医療局健康医務部健康対策課）<br /><a href="https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html#soudan" target="_blank" rel="noopener">https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html#soudan</a>'
+            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（愛知県保健医療局健康医務部健康対策課）<br /><a href="https://www.pref.aichi.jp/site/covid19-aichi/soudan.html#soudan" target="_blank" rel="noopener">https://www.pref.aichi.jp/site/covid19-aichi/soudan.html#soudan</a>'
         },
         {
           title: '3 その他',


### PR DESCRIPTION
## 📝 関連issue / Related Issues
#112

- close #112

## ⛏ 変更内容 / Details of Changes
- 愛知県内の発生状況についてのリンクの修正
  - 変更前: https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html 
  - 変更後: https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html
- 新型コロナウイルス感染症にかかる相談窓口についてのリンクを修正
  - 変更前: https://www.pref.aichi.jp/soshiki/kenkotaisaku/novel-coronavirus.html#soudan
  - 変更後: https://www.pref.aichi.jp/site/covid19-aichi/soudan.html#soudan
## 📸 スクリーンショット / Screenshots
### 各リンク先

###  愛知県内の発生状況についてのリンクの修正

#### before

<img width="1039" alt="スクリーンショット 2020-03-20 22 15 10" src="https://user-images.githubusercontent.com/39574826/77166831-47f69f00-6af8-11ea-9277-7cfd1240849b.png">
 
#### after

<img width="986" alt="スクリーンショット 2020-03-20 22 15 52" src="https://user-images.githubusercontent.com/39574826/77166896-60ff5000-6af8-11ea-9b80-5af76b9e7366.png">

### 新型コロナウイルス感染症にかかる相談窓口についてのリンクを修正

#### before
<img width="1039" alt="スクリーンショット 2020-03-20 22 15 10" src="https://user-images.githubusercontent.com/39574826/77166831-47f69f00-6af8-11ea-9277-7cfd1240849b.png">

#### after

<img width="1066" alt="スクリーンショット 2020-03-20 22 17 12" src="https://user-images.githubusercontent.com/39574826/77167015-90ae5800-6af8-11ea-844f-0c4c2644a11a.png">

