### PR TITLE
「最新のお知らせ」を愛知県のコロナに関するお知らせページへのリンクに変更

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,38 +1,32 @@
 <template>
   <div class="WhatsNew">
-    <h2 class="WhatsNew-heading">
-      <v-icon size="24" class="WhatsNew-heading-icon">
+    <a
+      class="WhatsNew-list-item-anchor"
+      :href="url"
+      target="_blank"
+      rel="noopener"
+    >
+      <v-icon size="18" class="WhatsNew-heading-icon">
         mdi-information
       </v-icon>
-      最新のお知らせ
-    </h2>
-    <ul class="WhatsNew-list">
-      <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
-        <a
-          class="WhatsNew-list-item-anchor"
-          :href="item.url"
-          target="_blank"
-          rel="noopener"
+      <time
+        v-if="date"
+        class="WhatsNew-list-item-anchor-time px-2"
+        :datetime="formattedDate(date)"
+      >
+        {{ date }}
+      </time>
+      <span class="WhatsNew-list-item-anchor-link">
+        {{ text }}
+        <v-icon
+          v-if="!isInternalLink(url)"
+          class="WhatsNew-item-ExternalLinkIcon"
+          size="12"
         >
-          <time
-            class="WhatsNew-list-item-anchor-time px-2"
-            :datetime="formattedDate(item.date)"
-          >
-            {{ item.date }}
-          </time>
-          <span class="WhatsNew-list-item-anchor-link">
-            {{ item.text }}
-            <v-icon
-              v-if="!isInternalLink(item.url)"
-              class="WhatsNew-item-ExternalLinkIcon"
-              size="12"
-            >
-              mdi-open-in-new
-            </v-icon>
-          </span>
-        </a>
-      </li>
-    </ul>
+          mdi-open-in-new
+        </v-icon>
+      </span>
+    </a>
   </div>
 </template>
 
@@ -41,8 +35,16 @@ import { convertDateToISO8601Format } from '@/utils/formatDate'
 
 export default {
   props: {
-    items: {
-      type: Array,
+    text: {
+      type: String,
+      required: true
+    },
+    date: {
+      type: String,
+      required: true
+    },
+    url: {
+      type: String,
       required: true
     }
   },
@@ -73,7 +75,8 @@ export default {
   margin-left: 12px;
 
   &-icon {
-    margin: 3px;
+    margin: 0 3px;
+    color: $gray-2 !important;
   }
 }
 

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -10,7 +10,6 @@
         mdi-information
       </v-icon>
       <time
-        v-if="date"
         class="WhatsNew-list-item-anchor-time px-2"
         :datetime="formattedDate(date)"
       >
@@ -96,7 +95,7 @@ export default {
       }
 
       &-time {
-        flex: 0 0 90px;
+        flex: 0 0 auto;
         @include lessThan($medium) {
           flex: 0 0 100%;
         }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -193,9 +193,9 @@ export default {
         date: Data.lastUpdate
       },
       newsItem: {
-        date: "",
-        url: "https://www.pref.aichi.jp/site/covid19-aichi/",
-        text: "愛知県発表の新型コロナウイルス感染症に関する情報はこちら"
+        date: '2020/03/11',
+        url: 'https://www.pref.aichi.jp/site/covid19-aichi/',
+        text: '愛知県発表の新型コロナウイルス感染症に関する情報はこちら'
       }
       // metroGraphOption: {
       //   responsive: true,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -193,7 +193,7 @@ export default {
         date: Data.lastUpdate
       },
       newsItem: {
-        date: '2020/03/11',
+        date: '',
         url: 'https://www.pref.aichi.jp/site/covid19-aichi/',
         text: '愛知県発表の新型コロナウイルス感染症に関する情報はこちら'
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,12 @@
       :title="headerItem.title"
       :date="headerItem.date"
     />
-    <whats-new class="mb-4" :items="newsItems" />
+    <whats-new
+      class="mb-4"
+      :text="newsItem.text"
+      :date="newsItem.date"
+      :url="newsItem.url"
+    />
     <!-- <static-info
       class="mb-4"
       :url="'/flow'"
@@ -187,7 +192,11 @@ export default {
         title: '愛知県内の最新感染動向',
         date: Data.lastUpdate
       },
-      newsItems: News.newsItems
+      newsItem: {
+        date: "",
+        url: "https://www.pref.aichi.jp/site/covid19-aichi/",
+        text: "愛知県発表の新型コロナウイルス感染症に関する情報はこちら"
+      }
       // metroGraphOption: {
       //   responsive: true,
       //   legend: {


### PR DESCRIPTION
## 📝 関連issue / Related Issues
#111

- close #111

## ⛏ 変更内容 / Details of Changes
「最新のお知らせ」の項目を北海道のサイトみたいに、愛知県の「[感染症対策ページ](https://www.pref.aichi.jp/site/covid19-aichi/)」へのリンクを貼る
リンク: https://www.pref.aichi.jp/site/covid19-aichi/

-  `components/WhatsNew.vue`
     - timeのスタイルを調整しアイコンとリンクの間を開けるように変更
     -  愛知県発表の新型コロナウイルス感染症に関する情報はこちらのテキスト
     - リンク作成 https://www.pref.aichi.jp/site/covid19-aichi/

- `pages/index.vue`
   - newsItemsから単数のnewsItemに変更
   - newsItemに今回対応するurlとtextを入れて`components/WhatsNew.vue`に渡す

### 北海道の参考画像
![image](https://user-images.githubusercontent.com/39574826/77237865-2a682900-6c0f-11ea-863c-4494a11f80fc.png)


## 📸 スクリーンショット / Screenshots

### before 

<img width="907" alt="スクリーンショット 2020-03-22 7 18 07" src="https://user-images.githubusercontent.com/39574826/77237656-4c60ac00-6c0d-11ea-96c6-aa68919ebffb.png">

### after

<img width="777" alt="スクリーンショット 2020-03-22 8 11 05" src="https://user-images.githubusercontent.com/39574826/77238581-c3e60980-6c14-11ea-8c5d-87ea8690861f.png">


