### PR TITLE
「検査陽性者の状況」から「※退院には、死亡退院を含む」の文言を削除

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -13,9 +13,7 @@
       :mobile-breakpoint="0"
       class="cardTable"
     />
-    <div class="note">
-      ※退院には、死亡退院を含む
-    </div>
+    <div class="note" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="info.lText"


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #151

## ⛏ 変更内容 / Details of Changes
- 「検査陽性者の状況」から「※退院には、死亡退院を含む」の文言を削除

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/749758/77820865-d8506780-7128-11ea-94a4-12d27fee8531.png)
