### PR TITLE
出典元表記、出典元リンクを追加+修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -27,7 +27,7 @@
         target="_blank"
         rel="noopener"
       >
-        愛知県内の発生状況について
+        出典: 愛知県新型コロナウイルス感染症対策サイト
         <v-icon class="ExternalLinkIcon" size="15">
           mdi-open-in-new
         </v-icon>

--- a/components/SvgCard.vue
+++ b/components/SvgCard.vue
@@ -1,5 +1,11 @@
 <template>
-  <data-view class="SvgCard" :title="title" :title-id="titleId" :date="date">
+  <data-view
+    class="SvgCard"
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :url="url"
+  >
     <template v-slot:button>
       <p class="Graph-Desc">
         （注）県内において疑い例または患者の濃厚接触者として検査を行ったものについて掲載<br />
@@ -40,6 +46,11 @@ export default {
     },
     date: {
       type: String,
+      default: ''
+    },
+    url: {
+      type: String,
+      required: false,
       default: ''
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -28,6 +28,9 @@
           title="検査陽性者の状況"
           :title-id="'details-of-confirmed-cases'"
           :date="headerItem.date"
+          :url="
+            'https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html'
+          "
         >
           <confirmed-cases-table v-bind="confirmedCases" />
         </svg-card>


### PR DESCRIPTION
## 📝 関連issue / Related Issues
#158 

## ⛏ 変更内容 / Details of Changes
- 出典元表記、出典元リンクを修正
-  「検査陽性者の状況」に出典元表記がないので追加 
## 📸 スクリーンショット / Screenshots
