### PR TITLE
実績値の前に、累計値と同様に、データソースに記載された時点日時を表示

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -96,7 +96,9 @@ export default {
       if (this.dataKind === 'transition') {
         return {
           lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
-          sText: `実績値（前日比：${this.displayTransitionRatio} ${this.unit}）`,
+          sText: `${this.chartData.slice(-1)[0].label} 実績値（前日比：${
+            this.displayTransitionRatio
+          } ${this.unit}）`,
           unit: this.unit
         }
       }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #162 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性患者数」、「検査実施件数」の「日別」の実績値の前にデータソースに記載された時点日時を表示します。「累計」の累計値の前に表示している値と同じものです。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
いずれも修正対応後のものです。

![image](https://user-images.githubusercontent.com/54654871/78335857-5bf6d200-75c9-11ea-90b9-4f663ce3716d.png)

![image](https://user-images.githubusercontent.com/54654871/78335902-7466ec80-75c9-11ea-88bb-31b98d086f9d.png)

