### PR TITLE
検査実施数グラフで集計単位の異なるデータを視覚的に区別した

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -124,7 +124,9 @@ export default {
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: '#bd3f4c',
+              backgroundColor: this.chartData.map(d => {
+                return d.summarized ? '#1976d2' : '#bd3f4c'
+              }),
               borderWidth: 0
             }
           ]

--- a/utils/formatGraph.ts
+++ b/utils/formatGraph.ts
@@ -1,12 +1,14 @@
 type DataType = {
   日付: Date
   小計: number
+  合算: string
 }
 
 type GraphDataType = {
   label: string
   transition: number
   cumulative: number
+  summarized: boolean
 }
 
 export default (data: DataType[]) => {
@@ -23,7 +25,8 @@ export default (data: DataType[]) => {
         graphData.push({
           label: `${date.getMonth() + 1}/${date.getDate()}`,
           transition: subTotal,
-          cumulative: patSum
+          cumulative: patSum,
+          summarized: !!d['合算']
         })
       }
     })

--- a/utils/formatRemarks.ts
+++ b/utils/formatRemarks.ts
@@ -12,6 +12,6 @@ export default (data: DataType[]) => {
     .filter(d => new Date(d['日付']) < today)
     .filter(d => d['合算'])
     .map(d => convertDateToShortFormat(new Date(d['日付']).toISOString()))
-    .join(',')
-  return joined !== '' ? `※${joined}は合算値(出典参照)` : ''
+    .join(', ')
+  return joined !== '' ? `※青色＜${joined}＞は合算値(出典参照)` : ''
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #209

## ⛏ 変更内容 / Details of Changes

* ``data.json`` で ``"合算": "〇"`` になっている日付のバー色を青に
* ``"合算": `` が ○以外 または 無し の場合は赤系
* Vue コンポーネントの都合上、検査実施件数 だけでなく 陽性患者数 にも対応しますがデータが無いので 陽性患者数 のチャートは変化無し

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/401369/78892012-83570e80-7aa3-11ea-91f8-568237666e8a.png)

