### PR TITLE
各グラフに表示期間を指定できるスライダーを追加

### DIFF
--- a/components/DateSelectSlider.vue
+++ b/components/DateSelectSlider.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-range-slider
+    v-model="sliderValue"
+    :value="sliderValue"
+    :label="'表示期間'"
+    :min="min"
+    :max="max"
+    thumb-label="always"
+    style="padding-top: 35px;"
+  >
+    <template v-slot:thumb-label="props">
+      {{ getSliderLabels(props.value) }}
+    </template>
+  </v-range-slider>
+</template>
+
+<script>
+export default {
+  name: 'DateSelectSlider',
+  props: {
+    chartData: {
+      type: Array,
+      required: true
+    },
+    value: {
+      type: Array,
+      required: true
+    },
+    min: {
+      type: Number,
+      required: true,
+      default: 0
+    },
+    max: {
+      type: Number,
+      required: true,
+      default: 1
+    },
+    minSpanDays: {
+      type: Number,
+      required: true,
+      default: 14
+    }
+  },
+  data() {
+    return {
+      sliderValue: this.value
+    }
+  },
+  watch: {
+    sliderValue(newValue, _oldValue) {
+      this.$emit('sliderInput', newValue)
+    }
+  },
+  methods: {
+    getSliderLabels(index) {
+      if (index < this.chartData.length) {
+        return this.chartData[index].label
+      }
+      return this.chartData[this.chartData.length - 1].label
+    }
+  }
+}
+</script>

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -17,6 +17,14 @@
       :options="options"
       :height="240"
     />
+    <date-select-slider
+      :chart-data="chartData"
+      :value="defaultDisplaySpan"
+      :min="spanMin"
+      :max="spanMax"
+      :min-span-days="minSpanDays"
+      @sliderInput="sliderUpdate"
+    />
     <div>
       <ul class="remarks">
         <li v-for="remarks_text in remarks" :key="remarks_text">
@@ -38,9 +46,14 @@
 <script>
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DateSelectSlider from '@/components/DateSelectSlider.vue'
 
 export default {
-  components: { DataView, DataViewBasicInfoPanel },
+  components: {
+    DataView,
+    DataViewBasicInfoPanel,
+    DateSelectSlider
+  },
   props: {
     title: {
       type: String,
@@ -108,12 +121,42 @@ export default {
       default: () => []
     }
   },
-  // data() {
-  //   return {
-  //     dataKind: 'transition'
-  //   }
-  // },
+  data() {
+    const minSpanDays = 14
+    const displaySpanLower =
+      !this.chartData || this.chartData.length < minSpanDays
+        ? 0
+        : this.chartData.length - minSpanDays
+    const displaySpanUpper =
+      !this.chartData || this.chartData.length < minSpanDays
+        ? 0
+        : this.chartData.length - 1
+    return {
+      minSpanDays,
+      defaultDisplaySpan: [displaySpanLower, displaySpanUpper],
+      displaySpan: [displaySpanLower, displaySpanUpper]
+    }
+  },
   computed: {
+    spanMin() {
+      return 0
+    },
+    spanMax() {
+      return this.chartData.length - 1
+    },
+    displayChartData() {
+      if (!this.chartData || this.chartData.length < this.minSpanDays) {
+        return this.chartData
+      }
+      const lowerIndex = this.displaySpan[0]
+      const lower = lowerIndex < this.chartData.length ? lowerIndex : 0
+      const upperIndex = this.displaySpan[1]
+      const upper =
+        upperIndex < this.chartData.length
+          ? upperIndex
+          : this.chartData.length - 1
+      return this.chartData.slice(lower, upper + 1)
+    },
     displayLatestValueRatio() {
       const lastDay = this.chartData.slice(-1)[0][this.latestValueField]
       const lastDayBefore = this.chartData.slice(-2)[0][this.latestValueField]
@@ -136,12 +179,12 @@ export default {
     },
     displayData() {
       return {
-        labels: this.chartData.map(d => {
+        labels: this.displayChartData.map(d => {
           return d.label
         }),
         datasets: this.chartLegends.map(legend => ({
           label: legend.label,
-          data: this.chartData.map(d => d[legend.field]),
+          data: this.displayChartData.map(d => d[legend.field]),
           borderWidth: 0,
           borderColor: 'white',
           backgroundColor: legend.backgroundColor
@@ -233,6 +276,9 @@ export default {
     }
   },
   methods: {
+    sliderUpdate(sliderValue) {
+      this.displaySpan = sliderValue
+    },
     formatDayBeforeRatio(dayBeforeRatio) {
       const dayBeforeRatioLocaleString = dayBeforeRatio.toLocaleString()
       switch (Math.sign(dayBeforeRatio)) {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #227 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- グラフに表示期間を指定できるスライダーを付けた

#### 北海道版との相違点
1. デフォルト期間は直近14日間
2. 最小期間は設けていない（北海道版とは実装が異なったためちょっと入れ辛くなった）
3. スライダーを動かすと表示期間に応じて縦軸も変動する


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![2020-04-19_00h29_20](https://user-images.githubusercontent.com/16362469/79642088-78ecf100-81d6-11ea-808c-4905ceb1f2ae.png)



北海道版との相違点など、改善点あれば言ってください。

