### PR TITLE
画面幅が狭いと「週別 | 日別 | 累計」セレクトボタンがあるグラフの文字がはみ出す表示バグを修正

### DIFF
--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -9,6 +9,7 @@
       v-ripple="false"
       value="weekly-transition"
       class="DataSelector-Button"
+      :x-small="true"
     >
       週別
     </v-btn>
@@ -16,10 +17,16 @@
       v-ripple="false"
       value="daily-transition"
       class="DataSelector-Button"
+      :x-small="true"
     >
       日別
     </v-btn>
-    <v-btn v-ripple="false" value="cumulative" class="DataSelector-Button">
+    <v-btn
+      v-ripple="false"
+      value="cumulative"
+      class="DataSelector-Button"
+      :x-small="true"
+    >
       累計
     </v-btn>
   </v-btn-toggle>
@@ -33,6 +40,7 @@
   &-Button {
     border: none !important;
     margin: 2px;
+    padding: 0 6px !important;
     border-radius: 4px !important;
     height: 24px !important;
     font-size: 12px !important;

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -1,9 +1,13 @@
 <template>
   <div class="DataView-DataInfo">
     <span class="DataView-DataInfo-summary">
-      <small class="DataView-DataInfo-summary-unit">{{ lTitle }}</small>
-      {{ lText }}
-      <small class="DataView-DataInfo-summary-unit">{{ unit }}</small>
+      <span class="DataView-DataInfo-summary-items">
+        <small class="DataView-DataInfo-summary-unit">{{ lTitle }}</small>
+      </span>
+      <span class="DataView-DataInfo-summary-items">{{ lText }}</span>
+      <span class="DataView-DataInfo-summary-items">
+        <small class="DataView-DataInfo-summary-unit">{{ unit }}</small>
+      </span>
     </span>
     <br />
     <small class="DataView-DataInfo-date">{{ sText }}</small>
@@ -19,8 +23,12 @@
       display: inline-block;
       font-family: Hiragino Sans;
       font-style: normal;
-      font-size: 30px;
+      font-size: 0;
       line-height: 30px;
+      &-items {
+        font-size: 30px;
+        margin: 0 2px;
+      }
       &-unit {
         font-size: 0.6em;
       }
@@ -28,6 +36,7 @@
     &-date {
       white-space: nowrap;
       display: inline-block;
+      margin-left: 4px;
       font-size: 12px;
       line-height: 12px;
       color: $gray-3;


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #320

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 選択ボタンを小さくした
- 右上の数値を単位の間の謎の空白をなくした

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![2020-04-28_16h49_52](https://user-images.githubusercontent.com/16362469/80462285-75ddc780-8971-11ea-86c9-404dcf7d340b.png)

