### PR TITLE
再:市町村別感染状況で画面幅がやや狭いと右にはみ出す

### DIFF
--- a/components/ColumnMap.vue
+++ b/components/ColumnMap.vue
@@ -8,7 +8,14 @@
     :remarks="remarks"
     :title-date="titleDate"
   >
-    <table class="tabularmaps">
+    <table
+      class="tabularmaps"
+      :class="
+        $vuetify.breakpoint.xs
+          ? 'ColumnMap-TableSpacingForXS'
+          : 'ColumnMap-TableSpacing'
+      "
+    >
       <tr v-for="(row, rowIndex) in table" :key="rowIndex">
         <td
           v-for="(col, colIndex) in row"
@@ -25,7 +32,7 @@
           <div>
             <div
               :class="
-                $vuetify.breakpoint.md
+                $vuetify.breakpoint.mdAndDown
                   ? 'ColumnMap-PanelTextForMD'
                   : 'ColumnMap-PanelText'
               "
@@ -96,6 +103,12 @@
     font-size: 11px;
     color: $gray-3;
   }
+  &-TableSpacing {
+    border-spacing: 5px;
+  }
+  &-TableSpacingForXS {
+    border-spacing: 1px;
+  }
   &-PanelText {
     font-size: 11px;
     line-height: 1.3;
@@ -107,7 +120,7 @@
   &-PanelTextForMD {
     font-size: 9px;
     line-height: 1.3;
-    width: calc(9px * 3.5);
+    width: calc(9px * 3.2);
     margin: 0 auto;
     white-space: nowrap;
     overflow: hidden;
@@ -177,7 +190,6 @@
 
 /* tabularmaps */
 .tabularmaps {
-  border-spacing: 5px;
   border-collapse: separate;
   display: inline-block;
   width: 100%; // 90vw;


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- #350

## ⛏ 変更内容 / Details of Changes

- 画面幅切り替えの条件指定が間違っていたので修正
- 画面幅約 340px までなら収まるようになった

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/401369/80583581-5b781c80-8a4b-11ea-92c6-22f9a199a4a8.png)
