### PR TITLE
Group patients_summary by week

### DIFF
--- a/tool/convert.php
+++ b/tool/convert.php
@@ -98,6 +98,7 @@ function readPatients() : array
       $row['date'] = $carbon->format('Y-m-d');
       $row['w'] = $carbon->format('w');
       $row['short_date'] = $carbon->format('m/d');
+      $row['start_of_week'] = $carbon->startOfWeek()->format('Y-m-d');
       return $row;
     })
   ];
@@ -116,7 +117,7 @@ function createSummary(array $patients) {
         '日付' => $key,
         '小計' => $val
       ];
-    })->merge($patients['data']->groupBy('発表日')->map(function ($group, $key) {
+    })->merge($patients['data']->groupBy('start_of_week')->map(function ($group, $key) {
       return [
         '日付' => $key,
         '小計' => $group->count()


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->

<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #354 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- Group patients_summary by week when we generate json data (For linked issue, I realized the issue is data itself instead of frontend implementation)

## Note

- `Carbon#startOfWeek` specifies Monday by default. If we change it to something else like Sunday, I can change it.
- I couldn't find tests for `convert.php`. Let me know if there is any way to verify its behavior