### PR TITLE
Google Search Consoleの所有者確認のMetaタグを追加

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -67,6 +67,10 @@ const config: Configuration = {
         hid: 'twitter:image',
         name: 'twitter:image',
         content: 'https://stopcovid19.code4.nagoya/ogp.png'
+      },
+      {
+        name: 'google-site-verification',
+        content: '1eIAbiY2dh-CPjLLY2LejVtfSp2WXQ8_DlLvjy7xsLE'
       }
     ],
     link: [


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #392 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- [Google Search Console](https://search.google.com/search-console?hl=ja) の所有者確認用のMetaタグを追加した。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
