### PR TITLE
緊急事態宣言の解除（県独自は継続）に併せて、トップの文言を変更

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,8 +7,8 @@
     />
     <whats-new
       class="mb-1"
-      text="全国を対象区域とした緊急事態宣言が 5/31 まで延長されました。愛知県は引き続き「特定警戒都道府県」 に指定されています"
-      url="https://corona.go.jp/"
+      text="5/14、政府は、愛知県の緊急事態宣言を解除しました。愛知県独自の「愛知県緊急事態宣言」は引き続き発出中です。"
+      url="https://www.pref.aichi.jp/site/covid19-aichi/2020051402.html"
     />
     <whats-new
       class="mb-1"


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #461

## ⛏ 変更内容 / Details of Changes
- 文言 5/14、政府は、愛知県の緊急事態宣言を解除しました。愛知県独自の「愛知県緊急事態宣言」は引き続き発出中です。
- リンク先 https://www.pref.aichi.jp/site/covid19-aichi/2020051402.html

に変更。
