### PR TITLE
「市町村別感染状況」が累計値であることを強調する #448

### DIFF
--- a/components/ColumnMap.vue
+++ b/components/ColumnMap.vue
@@ -56,7 +56,7 @@
         <div class="ColumnMap-LegendMapCell">
           <div class="ColumnMap-LegendMapText">
             <span>居住地</span>
-            <span>感染者数</span>
+            <span>累計感染者数</span>
             <span>感染率※</span>
           </div>
         </div>
@@ -146,7 +146,7 @@
     flex-direction: column;
   }
   &-LegendMapCell {
-    width: 60px;
+    width: calc(11px * 7);
     height: 60px;
     border: 1px solid #333;
     border-radius: 5px;
@@ -174,7 +174,7 @@
     justify-content: center;
     font-size: 11px;
     line-height: 1.3;
-    width: calc(11px * 4);
+    width: calc(11px * 7);
     margin: 0 auto;
     white-space: nowrap;
     overflow: hidden;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -75,7 +75,7 @@
 
       <v-col cols="12" md="6" class="DataCard">
         <column-map
-          title="市町村別感染状況"
+          title="市町村別感染者数"
           :title-id="'patients-per-cities'"
           :date="Data.patients.date"
           :data="patientsPerCities"


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ ISSUE NUMBER #{448}
-->

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 市町村別感染者数の数字が累計であることを強調
- 感染者数→累計感染者数
- 市町村別感染状況→市町村別感染者数
- 凡例のレイアウト変更
