### PR TITLE
新規感染者数グラフのタイトルを種別ごとに変更するようにした

### DIFF
--- a/components/NewPatientsChart.vue
+++ b/components/NewPatientsChart.vue
@@ -89,7 +89,9 @@ export default class NewPatientsChart extends Vue {
   private readonly chartDataSet = new Map<DataKind, GraphData>()
 
   private get displayTitle(): string {
-    return `新規感染者数${
+    return `${
+      this.dataKind === 'daily-cumulative' ? '累計' : '新規'
+    }感染者数${
       this.dataKind === 'weekly-transition' ? '(週別)' : ''
     }`
   }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #676

## ⛏ 変更内容 / Details of Changes
- 新規感染者数グラフのタイトルを以下のように変更した。
- 日別選択時（デフォルト）「新規感染者数」
- 週別選択時　　　　　　　「新規感染者数（週別）」
- 累計選択時　　　　　　　「累計感染者数」
