### PR TITLE
グラフのY軸ラベルや現在値に３桁カンマ区切りを適用する

### DIFF
--- a/components/ColumnMap.vue
+++ b/components/ColumnMap.vue
@@ -240,11 +240,12 @@ import {
   WeekCityPatientDataType,
   CityDataType
 } from '~/utils/formatPatientsPerCities'
+import { formatNumber } from '@/utils/formatNumber'
 
 type CitySummaryDataType = {
   cityCode: string // 市町村コード
   cityName: string // 市町村名
-  patientsTotal: number // 患者数
+  patientsTotal: string // 患者数
   patientsPer100k: string // 10万人あたり患者数
   legendIndex: number // 該当凡例
 }
@@ -441,7 +442,7 @@ export default class ColumnMap extends Vue {
           result.set(city['市町村コード'], {
             cityCode: city['市町村コード'], // 市町村コード
             cityName: city['市町村名'], // 市町村名
-            patientsTotal: countOfCity, // 患者数
+            patientsTotal: formatNumber(countOfCity), // 患者数
             patientsPer100k: patientsPer100kDisp,
             legendIndex
           } as CitySummaryDataType)

--- a/components/TimeBarLineChart.vue
+++ b/components/TimeBarLineChart.vue
@@ -25,6 +25,7 @@ import dayjs from 'dayjs'
 import Enumerable from 'linq'
 import { ChartLegendLabelItem, ChartLegendOptions } from 'chart.js'
 import DateSelectSlider from '@/components/DateSelectSlider.vue'
+import { formatNumber } from '@/utils/formatNumber'
 
 // グラフの種類
 export type GraphKind = 'bar' | 'line'
@@ -247,7 +248,9 @@ export default class TimeBarLineChart extends Vue {
                   })(value)
 
                   label =
-                    value == null ? '' : `${title}: ${formatValue} ${unit}`
+                    value == null
+                      ? ''
+                      : `${title}: ${formatNumber(formatValue)} ${unit}`
                 }
 
                 return {
@@ -330,7 +333,7 @@ export default class TimeBarLineChart extends Vue {
               stepSize: this.displayYAxisLeftSetting.step,
               callback: (value: any) => {
                 return this.displayYAxisLeftSetting.visibleAxisValue ?? true
-                  ? `${value}${this.displayYAxisLeftSetting.unit}`
+                  ? `${formatNumber(value)}${this.displayYAxisLeftSetting.unit}`
                   : ''
               }
             }

--- a/utils/formatNumber.ts
+++ b/utils/formatNumber.ts
@@ -4,5 +4,5 @@ export const formatNumber = (x: number | undefined, digits: number = 1) => {
   }
 
   const per = 10 ** digits
-  return String(Math.round(x * per) / per)
+  return Number(Math.round(x * per) / per).toLocaleString()
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- #524

## ⛏ 変更内容 / Details of Changes
- 以下に対して３桁カンマ区切りを適用
  - グラフY軸
  - ツールチップ
  - 「判断指標と達成状況」の値
  - 「市町村別感染状況」の感染者数（感染率は枠をはみ出すので対応せず）

※すべて対応完了したか不明なため、Issue は close せずに置いておきます。

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/35142774/89541297-2a249f00-d839-11ea-892e-60f28703dd18.png)
![image](https://user-images.githubusercontent.com/35142774/89541498-6c4de080-d839-11ea-8fb8-407f6cca5142.png)
![image](https://user-images.githubusercontent.com/35142774/89541732-b46d0300-d839-11ea-929a-ec0909adabdc.png)
![image](https://user-images.githubusercontent.com/35142774/89541854-d9617600-d839-11ea-9204-bf87acdf4e5a.png)
![image](https://user-images.githubusercontent.com/35142774/89541989-0746ba80-d83a-11ea-8389-c81585874f87.png)
![image](https://user-images.githubusercontent.com/35142774/89542180-483ecf00-d83a-11ea-8578-469f67348693.png)
