### PR TITLE
「入院患者数グラフ」と「判断指標と達成状況」の入院患者数を「入院等」から「入院」に変更

### DIFF
--- a/utils/types.ts
+++ b/utils/types.ts
@@ -66,6 +66,10 @@ export type MainSummaryDataType = {
   重症: number
   転院: number
   施設入所: number
+  入院: number
+  入院調整: number
+  自宅療養: number
+  調整: number
   死亡: number
   退院: number
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #845

## ⛏ 変更内容 / Details of Changes

###「入院患者数グラフ」「判断指標と達成状況」

- 入院患者数には、main_summaryの「入院」に、値が有れば「入院」を使い、空なら「入院等」を用いる
- 移動平均は混在したまま算出する
- 注記に『7/27以前の「入院患者数」には、「入院調整」「自宅療養」「調整」が含まれています』と追記する

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/401369/90025693-618bc380-dcf1-11ea-8998-ddd648621bc2.png)

![image](https://user-images.githubusercontent.com/401369/90025672-59cc1f00-dcf1-11ea-8894-dbd2f6348413.png)

