### PR TITLE
fix 新規感染者数パネルの「当サイトでCSV形式に加工したデータ」のリンク先が正しくない 

### DIFF
--- a/components/NewPatientsChart.vue
+++ b/components/NewPatientsChart.vue
@@ -76,7 +76,7 @@ export default class NewPatientsChart extends Vue {
   public weeklyData?: PatientsSummaryWeekly[]
 
   private readonly remarks = [
-    '「新規感染者数」とは、愛知県が発表する「<a class=RemarksLink target=_blank href=https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html>愛知県内発生事例</a>」を日別または週別に集計した人数です。(参考:<a class=RemarksLink target=_blank href=https://github.com/code4nagoya/covid19/blob/development/data/patients.csv>当サイトでCSV形式に加工したデータ</a>)。',
+    '「新規感染者数」とは、愛知県が発表する「<a class=RemarksLink target=_blank href=https://www.pref.aichi.jp/site/covid19-aichi/kansensya-kensa.html>愛知県内発生事例</a>」を日別または週別に集計した人数です。(参考:<a class=RemarksLink target=_blank href=https://github.com/code4nagoya/covid19/blob/master/data/patients.csv>当サイトでCSV形式に加工したデータ</a>)。',
     '過去7日間の平均は、新規感染者数の後方7日移動平均値です'
   ]
 


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1161
