### PR TITLE
緊急事態宣言を3/7まで延長

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
     />
     <whats-new
       class="mb-1"
-      text="1月14日、緊急事態宣言が発出されました（対象期間：1/14～2/7）"
+      text="1月14日、緊急事態宣言が発出されました（対象期間：1/14～3/7）"
       url="https://www.pref.aichi.jp/site/covid19-aichi/covid19-aichi.html"
     />
     <whats-new


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- #1138 

## ⛏ 変更内容 / Details of Changes

- 緊急事態宣言の終了予定日を 2/7 → 3/7 に変更

