### PR TITLE
緊急事態宣言が 2/28 をもって解除されたのでTop文言を削除

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,11 +5,11 @@
       :title="headerItem.title"
       :date="headerItem.date"
     />
-    <whats-new
+    <!--<whats-new
       class="mb-1"
       text="1月14日、緊急事態宣言が発出されました（対象期間：1/14～3/7）"
       url="https://www.pref.aichi.jp/site/covid19-aichi/covid19-aichi.html"
-    />
+    />-->
     <whats-new
       class="mb-1"
       :text="newsItem.text"


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1138

## ⛏ 変更内容 / Details of Changes
- Top ページの 緊急事態宣言 の欄を削除（また出るかも知れないのでコメントアウトしただけ）

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/401369/109502965-07abe900-7add-11eb-93d0-980963eb3eec.png)
